### PR TITLE
Remap conflicting name "shell".

### DIFF
--- a/src/Data/Conduit/Shell/TH.hs
+++ b/src/Data/Conduit/Shell/TH.hs
@@ -71,6 +71,7 @@ remap name =
    "truncate" -> "truncate'"
    "lex" -> "lex'"
    "env" -> "env'"
+   "shell" -> "shell'"
    e -> e
 
 -- | Get a list of all binaries in PATH.


### PR DESCRIPTION
Today I tried to install shell-conduit by following commands:

```
cd /tmp
mkdir shell-conduit
cd shell-conduit
cabal sandbox init
cabal install shell-conduit
```

Then, I took this error:

```
[6 of 6] Compiling Data.Conduit.Shell ( src/Data/Conduit/Shell.hs, dist/dist-sandbox-3fce14c2/build/Data/Conduit/Shell.o )

src/Data/Conduit/Shell.hs:90:4:
    Ambiguous occurrence ‘shell’
    It could refer to either ‘Data.Conduit.Shell.PATH.shell’,
                             imported from ‘Data.Conduit.Shell.PATH’ at src/Data/Conduit/Shell.hs:110:1-30
                             (and originally defined at src/Data/Conduit/Shell/PATH.hs:12:3-18)
                          or ‘Data.Conduit.Shell.Process.shell’,
                             imported from ‘Data.Conduit.Shell.Process’ at src/Data/Conduit/Shell.hs:111:1-33
                             (and originally defined
                                at src/Data/Conduit/Shell/Process.hs:46:1-5)
Failed to install shell-conduit-0.1
cabal: Error: some packages failed to install:
shell-conduit-0.1 failed during the building phase. The exception was:
ExitFailure 1
```

In my environment, `shell` command is in `PATH`.

```
$ which shell
/usr/local/bin/shell
```
